### PR TITLE
Copy only required libraries to output

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet publish -c Debug -r linux-x64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
+      run: dotnet publish -c Debug -r linux-x64 --self-contained true -p:CubismFrameworkRuntime=linux-x64 -p:PublishSingleFile=false -p:PublishTrimmed=true
 #    - name: Test
 #      run: dotnet test --no-restore --verbosity normal
     - name: Upload Nightly Artifact
@@ -37,7 +37,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet publish -c Debug -r win10-x64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
+      run: dotnet publish -c Debug -r win10-x64 --self-contained true -p:CubismFrameworkRuntime=win-x64 -p:PublishSingleFile=false -p:PublishTrimmed=true
 #    - name: Test
 #      run: dotnet test --no-restore --verbosity normal
     - name: Upload Nightly Artifact

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
             "args": [],
             "cwd": "${workspaceFolder}/holotrack.Desktop",
             "console": "internalConsole",
-            "stopAtEntry": false
+            "stopAtEntry": false,
+            "preLaunchTask": "build",
         },
         {
             "name": "Launch Tests",
@@ -21,8 +22,9 @@
             "program": "${workspaceFolder}/holotrack.Tests/bin/Debug/netcoreapp3.1/holotrack.Tests.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
             "stopAtEntry": false,
-            "console": "internalConsole"
+            "preLaunchTask": "build",
         },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "dotnet",
+            "windows": {
+                "args": [
+                    "build",
+                    "/p:CubismFrameworkRuntime=win-x64",
+                    "/p:GenerateFullPaths=true",
+                    "/t:build",
+                    "/consoleloggerparameters:NoSummary"
+                ],
+            },
+            "linux": {
+                "args": [
+                    "build",
+                    "/p:CubismFrameworkRuntime=linux-x64",
+                    "/p:GenerateFullPaths=true",
+                    "/t:build",
+                    "/consoleloggerparameters:NoSummary"
+                ],
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/holotrack/holotrack.csproj
+++ b/holotrack/holotrack.csproj
@@ -11,9 +11,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\**\*"/>
-    <None Include="NativeLibs\runtimes\**\*">
-      <Link>runtimes\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    <None Include="NativeLibs\runtimes\$(CubismFrameworkRuntime)\**\*">
+      <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <Target Name="CopyNativeLibs" BeforeTargets="Build">
+    <Message Text="Cubism Runtime: $(CubismFrameworkRuntime)" Importance="High"/>
+  </Target>
 </Project>


### PR DESCRIPTION
Finally fixes artifact builds from not running due to a missing library.