### PR TITLE
Initialize holotrack user configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Launch Game",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/holotrack.Desktop/bin/Debug/netcoreapp3.1/holotrack.Desktop.dll",
+            "program": "${workspaceFolder}/holotrack.Desktop/bin/x64/Debug/netcoreapp3.1/holotrack.Desktop.dll",
             "args": [],
             "cwd": "${workspaceFolder}/holotrack.Desktop",
             "console": "internalConsole",

--- a/holotrack.Tests/Visual/Interface/TestSceneSettingsControls.cs
+++ b/holotrack.Tests/Visual/Interface/TestSceneSettingsControls.cs
@@ -49,7 +49,7 @@ namespace holotrack.Tests.Visual.Interface
                     new SettingsColorPicker
                     {
                         Label = "Color Picker",
-                        Bindable = new Bindable<Colour4>(),
+                        Bindable = new Bindable<Colour4> { Value = Colour4.Black },
                     },
                     new SettingsSliderBar<float>
                     {

--- a/holotrack.Tests/Visual/Rendering/TestSceneAdjustableCubismSprite.cs
+++ b/holotrack.Tests/Visual/Rendering/TestSceneAdjustableCubismSprite.cs
@@ -17,7 +17,6 @@ namespace holotrack.Tests.Visual.Rendering
                 Asset = assets.Get(@"haru.haru.model3.json"),
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Adjustable = true,
             });
             
         }

--- a/holotrack/Configuration/HoloTrackConfigManager.cs
+++ b/holotrack/Configuration/HoloTrackConfigManager.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
+using osuTK;
+
+namespace holotrack.Configuration
+{
+    public class HoloTrackConfigManager : IniConfigManager<HoloTrackSetting>
+    {
+        internal const string FILENAME = @"holotrack.ini";
+        protected override string Filename => FILENAME;
+
+        public HoloTrackConfigManager(Storage storage, IDictionary<HoloTrackSetting, object> defaultOverrides = null)
+            : base(storage, defaultOverrides)
+        {
+        }
+
+        protected override void InitialiseDefaults()
+        {
+            Set(HoloTrackSetting.BackgroundMode, BackgroundMode.Color);
+            Set(HoloTrackSetting.BackgroundColor, Colour4.Green);
+            Set(HoloTrackSetting.BackgroundImage, "");
+            Set(HoloTrackSetting.BackgroundScale, 1.0f, 1.0f, 5.0f, 0.1f);
+            Set(HoloTrackSetting.BackgroundPositionX, 0.0f);
+            Set(HoloTrackSetting.BackgroundPositionY, 0.0f);
+
+            Set(HoloTrackSetting.Model, "haru.haru.model3.json");
+            Set(HoloTrackSetting.ModelScale, 1.0f, 0.5f, 10.0f, 0.1f);
+            Set(HoloTrackSetting.ModelPositionX, 0.0f);
+            Set(HoloTrackSetting.ModelPositionY, 0.0f);
+
+            Set(HoloTrackSetting.MouseDrag, false);
+            Set(HoloTrackSetting.MouseWheel, false);
+        }
+    }
+
+    public enum HoloTrackSetting
+    {
+        BackgroundMode,
+        BackgroundColor,
+        BackgroundImage,
+        BackgroundScale,
+        BackgroundPositionX,
+        BackgroundPositionY,
+
+        Model,
+        ModelScale,
+        ModelPositionX,
+        ModelPositionY,
+
+        MouseDrag,
+        MouseWheel,
+    }
+
+    public enum BackgroundMode
+    {
+        Image,
+        Color,
+    }
+}

--- a/holotrack/Configuration/HoloTrackConfigManager.cs
+++ b/holotrack/Configuration/HoloTrackConfigManager.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
-using osuTK;
 
 namespace holotrack.Configuration
 {
@@ -19,7 +18,7 @@ namespace holotrack.Configuration
         protected override void InitialiseDefaults()
         {
             Set(HoloTrackSetting.BackgroundMode, BackgroundMode.Color);
-            Set(HoloTrackSetting.BackgroundColor, Colour4.Green);
+            Set(HoloTrackSetting.BackgroundColor, new Colour4(0.0f, 1.0f, 0.0f, 1.0f));
             Set(HoloTrackSetting.BackgroundImage, "");
             Set(HoloTrackSetting.BackgroundScale, 1.0f, 1.0f, 5.0f, 0.1f);
             Set(HoloTrackSetting.BackgroundPositionX, 0.0f);

--- a/holotrack/Graphics/Interface/NumberBox.cs
+++ b/holotrack/Graphics/Interface/NumberBox.cs
@@ -39,19 +39,26 @@ namespace holotrack.Graphics.Interface
         where T : struct, IEquatable<T>, IComparable<T>, IConvertible
     {
         public readonly BindableNumber<T> CurrentNumber = new BindableNumber<T>();
-        private string defaultValue => default(T).ToString(NumberFormatInfo.InvariantInfo);
+        private static string default_string = default(T).ToString(NumberFormatInfo.InvariantInfo);
 
         public NumberTextBox()
         {
-            Text = defaultValue;
+            CurrentNumber.ValueChanged += e => Text = e.NewValue.ToString(NumberFormatInfo.InvariantInfo);
         }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Text = CurrentNumber.Value.ToString(NumberFormatInfo.InvariantInfo);
+        }
+
         protected override void OnTextCommitted(bool changed)
         {
             if (string.IsNullOrEmpty(Text))
-                Text = defaultValue;
+                Text = default_string;
 
-            CurrentNumber.Value = (T)Convert.ChangeType(string.IsNullOrEmpty(Text) ? defaultValue : Text, typeof(T));
-            Text = CurrentNumber.Value.ToString(NumberFormatInfo.InvariantInfo);
+            CurrentNumber.Value = (T)Convert.ChangeType(string.IsNullOrEmpty(Text) ? default_string : Text, typeof(T));
         }
 
         protected override bool CanAddCharacter(char c)

--- a/holotrack/HoloTrackGame.cs
+++ b/holotrack/HoloTrackGame.cs
@@ -5,7 +5,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Screens;
-using osuTK;
 
 namespace holotrack
 {
@@ -30,8 +29,6 @@ namespace holotrack
 
             Add(new DrawSizePreservingFillContainer
             {
-                TargetDrawSize = new Vector2(1280, 720),
-                Strategy = DrawSizePreservationStrategy.Maximum,
                 Child = new HoloTrackKeyBindingContainer
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/holotrack/HoloTrackGame.cs
+++ b/holotrack/HoloTrackGame.cs
@@ -1,3 +1,4 @@
+using holotrack.Input;
 using holotrack.Screens.Main;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -31,10 +32,14 @@ namespace holotrack
             {
                 TargetDrawSize = new Vector2(1280, 720),
                 Strategy = DrawSizePreservationStrategy.Maximum,
-                Child = globalBufferedContainer = new BufferedContainer
+                Child = new HoloTrackKeyBindingContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = new ScreenStack(new Main()),
+                    Child = globalBufferedContainer = new BufferedContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new ScreenStack(new Main()),
+                    },
                 },
             });
         }

--- a/holotrack/HoloTrackGameBase.cs
+++ b/holotrack/HoloTrackGameBase.cs
@@ -1,13 +1,18 @@
+using holotrack.Configuration;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Cubism;
 using osu.Framework.Input;
 using osu.Framework.IO.Stores;
+using osu.Framework.Platform;
 
 namespace holotrack
 {
     public class HoloTrackGameBase : Game
     {
+        protected HoloTrackConfigManager LocalConfig;
+        protected Storage Storage { get; set; }
+
         private DependencyContainer dependencies;
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
@@ -29,6 +34,8 @@ namespace holotrack
             var cameraManager = new CameraManager(Host.UpdateThread) { EventScheduler = Scheduler };
             dependencies.Cache(cameraManager);
 
+            dependencies.Cache(LocalConfig);
+
             AddFont(Resources, @"Fonts/NotoExtraCond");
             AddFont(Resources, @"Fonts/NotoExtraCond-Italic");
             AddFont(Resources, @"Fonts/NotoExtraCond-Light");
@@ -39,6 +46,14 @@ namespace holotrack
             AddFont(Resources, @"Fonts/NotoExtraCond-MediumItalic");
             AddFont(Resources, @"Fonts/NotoExtraCond-Black");
             AddFont(Resources, @"Fonts/NotoExtraCond-BlackItalic");
+        }
+
+        public override void SetHost(GameHost host)
+        {
+            base.SetHost(host);
+
+            Storage ??= host.Storage;
+            LocalConfig ??= new HoloTrackConfigManager(Storage);
         }
     }
 }

--- a/holotrack/Input/HoloTrackKeyBindingContainer.cs
+++ b/holotrack/Input/HoloTrackKeyBindingContainer.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using osu.Framework.Input.Bindings;
+
+namespace holotrack.Input
+{
+    public class HoloTrackKeyBindingContainer : KeyBindingContainer<HoloTrackAction>
+    {
+        public HoloTrackKeyBindingContainer(SimultaneousBindingMode simultaneousMode = SimultaneousBindingMode.None, KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Modifiers)
+            : base(simultaneousMode, matchingMode)
+        {
+        }
+
+        public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+        {
+            new KeyBinding(new[] { InputKey.F1 }, HoloTrackAction.ToggleSettings),
+            new KeyBinding(new[] { InputKey.F2 }, HoloTrackAction.ToggleCamera),
+        };
+    }
+
+    public enum HoloTrackAction
+    {
+        ToggleCamera,
+        ToggleSettings,
+    }
+}

--- a/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSelect.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSelect.cs
@@ -1,6 +1,6 @@
 namespace holotrack.Overlays.Settings.Sections.Appearance
 {
-    public class BackgroundSelect : SettingsSubSection
+    public class BackgroundSelect : SettingsSubsection
     {
         public BackgroundSelect()
         {

--- a/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSelect.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSelect.cs
@@ -2,10 +2,6 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
 {
     public class BackgroundSelect : SettingsSubsection
     {
-        public BackgroundSelect()
-        {
-            HeaderText = @"Background";
-            SubHeaderText = @"coming soon(TM)!";
-        }
+        public override string Header => @"Background";
     }
 }

--- a/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSettings.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSettings.cs
@@ -1,6 +1,7 @@
+using holotrack.Configuration;
 using holotrack.Graphics.Interface;
 using holotrack.Graphics.Sprites;
-using osu.Framework.Bindables;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osuTK;
@@ -9,7 +10,8 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
 {
     public class BackgroundSettings : SettingsSubSection
     {
-        public BackgroundSettings()
+        [BackgroundDependencyLoader]
+        private void load(HoloTrackConfigManager config)
         {
             HeaderText = @"Background Settings";
             SubHeaderText = @"Customize your scenery";
@@ -17,10 +19,13 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
             Add(new SettingsColorPicker
             {
                 Label = @"Background Color",
-                Bindable = new Bindable<Colour4>
-                {
-                    Default = Colour4.Green,
-                },
+                Bindable = config.GetBindable<Colour4>(HoloTrackSetting.BackgroundColor),
+            });
+
+            Add(new SettingsSliderBar<float>
+            {
+                Label = @"Scale",
+                Bindable = config.GetBindable<float>(HoloTrackSetting.BackgroundScale),
             });
 
             Add(new FillFlowContainer
@@ -52,13 +57,13 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
                                 {
                                     Width = 0.75f,
                                     BadgeText = @"X",
-                                    Bindable = new BindableFloat(),
+                                    Bindable = config.GetBindable<float>(HoloTrackSetting.BackgroundPositionX),
                                 },
                                 new SettingsBadgedNumberBox<float>
                                 {
                                     Width = 0.75f,
                                     BadgeText = @"Y",
-                                    Bindable = new BindableFloat(),
+                                    Bindable = config.GetBindable<float>(HoloTrackSetting.BackgroundPositionY),
                                     Anchor = Anchor.TopRight,
                                     Origin = Anchor.TopRight,
                                 },
@@ -68,25 +73,11 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
                 }
             });
 
-            Add(new SettingsSliderBar<float>
-            {
-                Label = @"Scale",
-                Bindable = new BindableFloat
-                {
-                    MinValue = 1.0f,
-                    MaxValue = 5.0f,
-                    Precision = 0.1f,
-                    Default = 1.0f,
-                    Value = 1.0f,
-                }
-            });
-
             Add(new HoloTrackButton
             {
                 Text = @"Reset",
                 BackgroundColor = Colour4.Red,
                 RelativeSizeAxes = Axes.X,
-                Action = () => {},
             });
         }
     }

--- a/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSettings.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSettings.cs
@@ -10,12 +10,11 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
 {
     public class BackgroundSettings : SettingsSubsection
     {
+        public override string Header => @"Background Settings";
+
         [BackgroundDependencyLoader]
         private void load(HoloTrackConfigManager config)
         {
-            HeaderText = @"Background Settings";
-            SubHeaderText = @"Customize your scenery";
-
             Add(new SettingsColorPicker
             {
                 Label = @"Background Color",

--- a/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSettings.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/BackgroundSettings.cs
@@ -8,7 +8,7 @@ using osuTK;
 
 namespace holotrack.Overlays.Settings.Sections.Appearance
 {
-    public class BackgroundSettings : SettingsSubSection
+    public class BackgroundSettings : SettingsSubsection
     {
         [BackgroundDependencyLoader]
         private void load(HoloTrackConfigManager config)

--- a/holotrack/Overlays/Settings/Sections/Appearance/ModelSelect.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/ModelSelect.cs
@@ -1,6 +1,6 @@
 namespace holotrack.Overlays.Settings.Sections.Appearance
 {
-    public class ModelSelect : SettingsSubSection
+    public class ModelSelect : SettingsSubsection
     {
         public ModelSelect()
         {

--- a/holotrack/Overlays/Settings/Sections/Appearance/ModelSelect.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/ModelSelect.cs
@@ -2,10 +2,6 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
 {
     public class ModelSelect : SettingsSubsection
     {
-        public ModelSelect()
-        {
-            HeaderText = @"Model";
-            SubHeaderText = @"coming soon(TM)!";
-        }
+        public override string Header => @"Model";
     }
 }

--- a/holotrack/Overlays/Settings/Sections/Appearance/ModelSettings.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/ModelSettings.cs
@@ -8,7 +8,7 @@ using osuTK;
 
 namespace holotrack.Overlays.Settings.Sections.Appearance
 {
-    public class ModelSettings : SettingsSubSection
+    public class ModelSettings : SettingsSubsection
     {
         [BackgroundDependencyLoader]
         private void load(HoloTrackConfigManager config)

--- a/holotrack/Overlays/Settings/Sections/Appearance/ModelSettings.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/ModelSettings.cs
@@ -1,6 +1,7 @@
+using holotrack.Configuration;
 using holotrack.Graphics.Interface;
 using holotrack.Graphics.Sprites;
-using osu.Framework.Bindables;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osuTK;
@@ -9,10 +10,17 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
 {
     public class ModelSettings : SettingsSubSection
     {
-        public ModelSettings()
+        [BackgroundDependencyLoader]
+        private void load(HoloTrackConfigManager config)
         {
             HeaderText = @"Model Settings";
             SubHeaderText = @"Make adjustments to the Live2D model";
+
+            Add(new SettingsSliderBar<float>
+            {
+                Label = @"Scale",
+                Bindable = config.GetBindable<float>(HoloTrackSetting.ModelScale)
+            });
 
             Add(new FillFlowContainer
             {
@@ -43,13 +51,13 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
                                 {
                                     Width = 0.75f,
                                     BadgeText = @"X",
-                                    Bindable = new BindableFloat(),
+                                    Bindable = config.GetBindable<float>(HoloTrackSetting.ModelPositionX),
                                 },
                                 new SettingsBadgedNumberBox<float>
                                 {
                                     Width = 0.75f,
                                     BadgeText = @"Y",
-                                    Bindable = new BindableFloat(),
+                                    Bindable = config.GetBindable<float>(HoloTrackSetting.ModelPositionY),
                                     Anchor = Anchor.TopRight,
                                     Origin = Anchor.TopRight,
                                 },
@@ -57,31 +65,18 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
                         },
                     }
                 }
-            });
-
-            Add(new SettingsSliderBar<float>
-            {
-                Label = @"Scale",
-                Bindable = new BindableFloat
-                {
-                    MinValue = 0.5f,
-                    MaxValue = 10.0f,
-                    Precision = 0.1f,
-                    Default = 1.0f,
-                    Value = 1.0f,
-                },
-            });
+            }); 
 
             Add(new SettingsCheckbox
             {
                 Label = @"Mouse drag moves the model",
-                Bindable = new BindableBool(),
+                Bindable = config.GetBindable<bool>(HoloTrackSetting.MouseDrag),
             });
 
             Add(new SettingsCheckbox
             {
                 Label = @"Mouse wheel scales the model",
-                Bindable = new BindableBool(),
+                Bindable = config.GetBindable<bool>(HoloTrackSetting.MouseWheel),
             });
 
             Add(new HoloTrackButton
@@ -89,7 +84,6 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
                 Text = @"Reset",
                 BackgroundColor = Colour4.Red,
                 RelativeSizeAxes = Axes.X,
-                Action = () => {},
             });
         }
     }

--- a/holotrack/Overlays/Settings/Sections/Appearance/ModelSettings.cs
+++ b/holotrack/Overlays/Settings/Sections/Appearance/ModelSettings.cs
@@ -10,12 +10,11 @@ namespace holotrack.Overlays.Settings.Sections.Appearance
 {
     public class ModelSettings : SettingsSubsection
     {
+        public override string Header => @"Model Settings";
+
         [BackgroundDependencyLoader]
         private void load(HoloTrackConfigManager config)
         {
-            HeaderText = @"Model Settings";
-            SubHeaderText = @"Make adjustments to the Live2D model";
-
             Add(new SettingsSliderBar<float>
             {
                 Label = @"Scale",

--- a/holotrack/Overlays/Settings/Sections/AppearanceSection.cs
+++ b/holotrack/Overlays/Settings/Sections/AppearanceSection.cs
@@ -1,9 +1,5 @@
-using holotrack.Graphics.Interface;
 using holotrack.Overlays.Settings.Sections.Appearance;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Screens;
-using osuTK;
 
 namespace holotrack.Overlays.Settings.Sections
 {

--- a/holotrack/Overlays/Settings/Sections/SettingsSubsection.cs
+++ b/holotrack/Overlays/Settings/Sections/SettingsSubsection.cs
@@ -1,4 +1,5 @@
 using holotrack.Graphics;
+using holotrack.Graphics.Sprites;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osuTK;
@@ -7,29 +8,7 @@ namespace holotrack.Overlays.Settings
 {
     public abstract class SettingsSubsection : FillFlowContainer
     {
-        private TextFlowContainer header;
-        private string headerText;
-        public string HeaderText
-        {
-            get => headerText;
-            set
-            {
-                headerText = value;
-                header.AddText($"{headerText}\n", s => s.Font = HoloTrackFont.Black.With(size: 20));
-            }
-        }
-
-        private string subHeaderText;
-        public string SubHeaderText
-        {
-            get => subHeaderText;
-            set
-            {
-                subHeaderText = value;
-                header.AddText(subHeaderText, s => s.Font = HoloTrackFont.Medium.With(size: 16));
-            }
-        }
-
+        public abstract string Header { get; }
 
         protected FillFlowContainer Items;
         protected override Container<Drawable> Content => Items;
@@ -43,10 +22,10 @@ namespace holotrack.Overlays.Settings
 
             InternalChildren = new Drawable[]
             {
-                header = new TextFlowContainer(s => s.Font = HoloTrackFont.Default)
+                new HoloTrackSpriteText
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
+                    Text = Header,
+                    Font = HoloTrackFont.Black.With(size: 20),
                 },
                 Items = new FillFlowContainer
                 {

--- a/holotrack/Overlays/Settings/SettingsOverlay.cs
+++ b/holotrack/Overlays/Settings/SettingsOverlay.cs
@@ -28,7 +28,7 @@ namespace holotrack.Overlays.Settings
                     RelativeSizeAxes = Axes.Both,
                     ColumnDimensions = new[]
                     {
-                        new Dimension(GridSizeMode.Absolute, 230),
+                        new Dimension(GridSizeMode.Absolute, 200),
                         new Dimension(GridSizeMode.Distributed),
                     },
                     Content = new[]

--- a/holotrack/Overlays/Settings/SettingsSubSection.cs
+++ b/holotrack/Overlays/Settings/SettingsSubSection.cs
@@ -26,7 +26,7 @@ namespace holotrack.Overlays.Settings
             set
             {
                 subHeaderText = value;
-                header.AddText(subHeaderText, s => s.Font = HoloTrackFont.Default.With(size: 12));
+                header.AddText(subHeaderText, s => s.Font = HoloTrackFont.Medium.With(size: 16));
             }
         }
 

--- a/holotrack/Overlays/Settings/SettingsSubSection.cs
+++ b/holotrack/Overlays/Settings/SettingsSubSection.cs
@@ -5,7 +5,7 @@ using osuTK;
 
 namespace holotrack.Overlays.Settings
 {
-    public abstract class SettingsSubSection : FillFlowContainer
+    public abstract class SettingsSubsection : FillFlowContainer
     {
         private TextFlowContainer header;
         private string headerText;
@@ -34,7 +34,7 @@ namespace holotrack.Overlays.Settings
         protected FillFlowContainer Items;
         protected override Container<Drawable> Content => Items;
 
-        public SettingsSubSection()
+        public SettingsSubsection()
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;

--- a/holotrack/Screens/Main/AdjustableBackground.cs
+++ b/holotrack/Screens/Main/AdjustableBackground.cs
@@ -1,0 +1,72 @@
+using holotrack.Configuration;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osuTK;
+
+namespace holotrack.Screens.Main
+{
+    public class AdjustableBackground : Container
+    {
+        private readonly Sprite background;
+        private Bindable<float> userScale;
+        private Bindable<float> userXOffset;
+        private Bindable<float> userYOffset;
+        private Bindable<BackgroundMode> backgroundMode;
+        private Bindable<string> userTexture;
+        private Bindable<Colour4> userColor;
+
+        public AdjustableBackground()
+        {
+            Child = background = new Sprite
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(HoloTrackConfigManager config)
+        {
+            userScale = config.GetBindable<float>(HoloTrackSetting.BackgroundScale);
+            userXOffset = config.GetBindable<float>(HoloTrackSetting.BackgroundPositionX);
+            userYOffset = config.GetBindable<float>(HoloTrackSetting.BackgroundPositionY);
+
+            backgroundMode = config.GetBindable<BackgroundMode>(HoloTrackSetting.BackgroundMode);
+            userTexture = config.GetBindable<string>(HoloTrackSetting.BackgroundImage);
+            userColor = config.GetBindable<Colour4>(HoloTrackSetting.BackgroundColor);
+
+            userScale.ValueChanged += _ => updateTranslation();
+            userXOffset.ValueChanged += _ => updateTranslation();
+            userYOffset.ValueChanged += _ => updateTranslation();
+
+            backgroundMode.ValueChanged += _ => updateTexture();
+            userTexture.ValueChanged += _ => updateTexture();
+            userColor.ValueChanged += _ => updateTexture();
+
+            updateTranslation();
+            updateTexture();
+        }
+
+        private void updateTranslation()
+        {
+            background.Position = new Vector2(userXOffset.Value, userYOffset.Value);
+            background.Size = new Vector2(userScale.Value);
+        }
+
+        private void updateTexture()
+        {
+            switch (backgroundMode.Value)
+            {
+                case BackgroundMode.Color:
+                    background.Texture = Texture.WhitePixel;
+                    background.Colour = userColor.Value;
+                    break;
+            }
+        }
+    }
+}

--- a/holotrack/Screens/Main/Main.cs
+++ b/holotrack/Screens/Main/Main.cs
@@ -1,30 +1,51 @@
+using holotrack.Input;
+using holotrack.Overlays.Settings;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cubism;
-using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Screens;
 
 namespace holotrack.Screens.Main
 {
-    public class Main : Screen
+    public class Main : Screen, IKeyBindingHandler<HoloTrackAction>
     {
+        private SettingsOverlay settings = new SettingsOverlay();
+
         [BackgroundDependencyLoader]
         private void load(CubismAssetStore assets)
         {
+
             AddRangeInternal(new Drawable[]
             {
-                new Box
+                new AdjustableBackground
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Colour4.Green,
                 },
                 new AdjustableCubismSprite
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Adjustable = true,
                     Asset = assets.Get(@"haru_greeter.haru_greeter.model3.json"),
                 },
+                settings
             });
+        }
+
+        public bool OnPressed(HoloTrackAction action)
+        {
+            switch (action)
+            {
+                case HoloTrackAction.ToggleSettings:
+                    settings.ToggleVisibility();
+                    return true;
+                
+                default:
+                    return false;
+            }
+        }
+
+        public void OnReleased(HoloTrackAction action)
+        {
         }
     }
 }


### PR DESCRIPTION
Creates a `holotrack.ini` in the game's directory. Settings are now visible to the main app and can be toggled via <kbd>F1</kbd>. Changes within settings are automatically saved and persist between sessions. This safely closes #12 and supersedes #17 . Camera display and file imports will come later.